### PR TITLE
Fix test

### DIFF
--- a/tests/testthat/test-conversions.R
+++ b/tests/testthat/test-conversions.R
@@ -150,7 +150,7 @@ test_that("from seededlda", {
   ))
   slda <- textmodel_seededlda(dfm(ECB_press_conferences_tokens),
                               dict, residual = TRUE,
-                              k = 6, max_iter = 100)
+                              max_iter = 100)
   LDA <- as.LDA(slda)
 
   expect_true(check_integrity(LDA))


### PR DESCRIPTION
@odelmarcelle My seededlda v1.4.0, submitted to CRAN today, triggered a reverse dependency error. Please merge this PR to correct your test: `textmodel_seededlda()` does not have `k` argument.

```
   
    ══ Failed tests ════════════════════════════════════════════════════════════════
    ── Error ('test-conversions.R:151:3'): from seededlda ──────────────────────────
    Error in `dfm_trim(x, ..., verbose = FALSE)`: unused argument (k = 6)
    Backtrace:
        ▆
     1. ├─seededlda::textmodel_seededlda(...) at test-conversions.R:151:3
     2. └─seededlda:::textmodel_seededlda.dfm(...)
     3.   └─seededlda:::tfm(...)
    
    [ FAIL 1 | WARN 0 | SKIP 1 | PASS 341 ]
    Error: Test failures
    Execution halted
```