### PR TITLE
Support quanteda 4.5.0 (fix token type-table handling)

### DIFF
--- a/R/models.R
+++ b/R/models.R
@@ -320,6 +320,13 @@ sentopicsmodel <- function(
 
   x <- quanteda::as.tokens(x)
 
+  ## Since quanteda 4.5.0, subsetting a tokens object no longer compacts its
+  ## type table: types inherited from the parent object are retained even when
+  ## they no longer appear. The vocabulary is built from the type table, so
+  ## these phantom types would inflate it (and break the type/feature alignment
+  ## in computeFcm()). Drop the unused types before building the model.
+  x <- recompileTypes(x)
+
   if (reverse) {
     S <- L2
   } else {

--- a/R/timeSeries.R
+++ b/R/timeSeries.R
@@ -257,7 +257,7 @@ sentopics_sentiment <- function(
     }
     cols <- grep("^\\.s_", names(docvars), value = TRUE)
     for (c in cols) {
-      docvars(x$tokens, c) <- NULL
+      quanteda::docvars(x$tokens, c) <- NULL
     }
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1007,6 +1007,22 @@ custom_handler <- function() {
   }
 }
 
+## Drop types that no longer appear in a tokens object. quanteda compacted the
+## type table automatically on subsetting before 4.5.0; from 4.5.0 onwards this
+## must be requested explicitly via the (internal) tokens_recompile(force=).
+## Only meaningful for user-supplied tokens/dfm: the conversion helpers build
+## tokens from an external vocabulary whose unused entries must be preserved.
+recompileTypes <- function(toks) {
+  tokens_recompile <- get("tokens_recompile", envir = getNamespace("quanteda"))
+  if ("force" %in% names(formals(tokens_recompile))) {
+    tokens_recompile(toks, force = TRUE)
+  } else {
+    ## Older quanteda already compacts on subset; recompile as a no-op safeguard.
+    tokens_recompile(toks)
+  }
+}
+
+
 makeVocabulary <- function(toks, dictionary, S) {
   ## CMD checks
   word <- NULL

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -12,7 +12,11 @@ test_that("virtualDocuments works", {
 })
 
 test_that("as.tokens.dfm works", {
-  toks <- ECB_press_conferences_tokens[1:10]
+  ## quanteda (>= 4.5.0) no longer compacts the type table when subsetting, so
+  ## `[1:10]` retains phantom types from the parent object. Reconstructing from
+  ## a dfm always yields compacted tokens, so recompile the reference to make
+  ## the round-trip comparison meaningful.
+  toks <- recompileTypes(ECB_press_conferences_tokens[1:10])
   dfm <- quanteda::dfm(toks, tolower = FALSE)
   expect_silent(LDA <- LDA(dfm))
   expect_silent(JST <- JST(dfm))


### PR DESCRIPTION
## Why

quanteda 4.5.0 is currently held back on CRAN because it breaks its reverse dependency **sentopics**. This PR fixes sentopics so that quanteda 4.5.0 can be released.

The root cause is a behaviour change in quanteda 4.5.0: **subsetting a tokens object no longer compacts its type table.** A subset such as `ECB_press_conferences_tokens[1:10]` now retains *all* types inherited from the parent object (e.g. 1168) instead of only the types that actually appear in the subset (e.g. 53).

sentopics builds a model's vocabulary directly from `attr(toks, "types")`, so these phantom types inflated every model's vocabulary. This surfaced as:

- **`chains_scores()` / `coherence()` errors** — `computeFcm()` indexed the full type table into a dfm that only contains the appearing features, giving `Error: Subscript out of bounds`.
- **Bloated vocabularies** in models built from subset tokens, with corresponding test failures (`types: Lengths (53, 1168) differ`).

## What this PR does

1. **Recompile the token type table at model creation.** A new internal helper `recompileTypes()` drops types that no longer appear, applied at the single point where user-supplied `tokens`/`dfm` enter a model (`sentopicsmodel()`, the shared backend for `LDA()`, `JST()`, `rJST()`). This restores the pre-4.5.0 vocabulary.
   - It is **deliberately not** applied in `makeVocabulary()`: the `as.LDA` / `as.rJST` / ... conversion helpers build tokens from an external vocabulary whose zero-count entries must be preserved to keep the topic-word matrices aligned.
   - The helper is guarded to remain **backward compatible with `quanteda (>= 3.2.0)`**, where subsetting already compacts the type table.

2. **Fix an unqualified `docvars<-` call** in `sentopics_sentiment<-`. Only the `docvars` getter is imported from quanteda, so clearing stale per-topic sentiment docvars raised `could not find function 'docvars<-'`. Now qualified as `quanteda::docvars(...) <- NULL`.

3. **Update a stale test fixture** (`as.tokens.dfm`) that relied on the pre-4.5.0 behaviour of a subset tokens object.

## Verification

`R CMD check` passes on both examples and tests against quanteda 4.5.0:

- `checking examples ... OK`
- `checking tests ... OK` (351 passing, 0 failures)

No minimum-version bump is required; the fix works across quanteda 3.2.0 – 4.5.0+.